### PR TITLE
Cube integration

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ce/api/Tools.java
+++ b/api/src/main/java/org/jboss/arquillian/ce/api/Tools.java
@@ -88,7 +88,7 @@ public final class Tools {
         // Install the all-trusting trust manager
         final SSLContext sc = SSLContext.getInstance("SSL");
         sc.init(null, trustAllCerts, new java.security.SecureRandom());
-        HttpsURLConnection.setDefaultSSLSocketFactory(new DelegatingSSLSocketFactory(sc.getSocketFactory()));
+        HttpsURLConnection.setDefaultSSLSocketFactory(createSSLSocketFactory(sc));
         // Create all-trusting host name verifier
         HostnameVerifier allHostsValid = new HostnameVerifier() {
             public boolean verify(String hostname, SSLSession session) {
@@ -98,6 +98,16 @@ public final class Tools {
 
         // Install the all-trusting host verifier
         HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+    }
+
+    private static SSLSocketFactory createSSLSocketFactory(final SSLContext sc) {
+        try {
+            Class.forName("javax.net.ssl.SNIHostName");
+        } catch (ClassNotFoundException e) {
+            // Java 7, no need to patch
+            return sc.getSocketFactory();
+        }
+        return new DelegatingSSLSocketFactory(sc.getSocketFactory());
     }
 
     private static final class DelegatingSSLSocketFactory extends SSLSocketFactory {

--- a/cube/pom.xml
+++ b/cube/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>arquillian-parent-ce</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>arquillian-ce-cube</artifactId>
+    <packaging>jar</packaging>
+    <name>Arquillian Container Cube Integration</name>
+    <description>Cloud Enablement integration with Arquillian Cube</description>
+
+    <properties>
+        <version.arquillian.cube>1.0.0.Final-SNAPSHOT</version.arquillian.cube>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+        		<groupId>org.arquillian.cube</groupId>
+            	<artifactId>arquillian-cube-parent</artifactId>
+                <version>${version.arquillian.cube}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-ce-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-ce-fabric8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+    		<groupId>org.arquillian.cube</groupId>
+        	<artifactId>arquillian-cube-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>
+
+
+

--- a/cube/pom.xml
+++ b/cube/pom.xml
@@ -16,7 +16,7 @@
     <description>Cloud Enablement integration with Arquillian Cube</description>
 
     <properties>
-        <version.arquillian.cube>1.0.0.Final-SNAPSHOT</version.arquillian.cube>
+        <version.arquillian.cube>1.0.0.Alpha9</version.arquillian.cube>
     </properties>
 
     <dependencyManagement>

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEApplicationHandler.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEApplicationHandler.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
  * contributors as indicated by the @author tags. All rights reserved.
  * See the copyright.txt in the distribution for a full listing of
  * individual contributors.
@@ -20,13 +20,22 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.arquillian.ce.cube;
 
-package org.jboss.arquillian.ce.shrinkwrap;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.core.api.annotation.Observes;
 
 /**
- * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
+ * CEApplicationHandler
+ * <p/>
+ * Manages "applications" declared for CE test cases.
+ * 
+ * @author Rob Cernich
  */
-public interface PomStrategy {
-    String[] profiles();
-    String toPom();
+public class CEApplicationHandler {
+
+    
+    public void registerCubes(@Observes OpenShiftClient client, CECubeConfiguration config) {
+        // TODO: add cubes for configured "applications"
+    }
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import org.jboss.arquillian.ce.utils.Configuration;
 import org.jboss.arquillian.ce.utils.Strings;
-import org.jboss.arquillian.container.spi.ConfigurationException;
 
 /**
  * CECubeConfiguration
@@ -42,6 +41,10 @@ public class CECubeConfiguration extends Configuration {
     private String templateLabels = Strings.getSystemPropertyOrEnvVar("openshift.template.labels");
     private String templateParameters = Strings.getSystemPropertyOrEnvVar("openshift.template.parameters");
     private boolean templateProcess = Boolean.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.template.process", "true"));
+    private String routerHost = Strings.getSystemPropertyOrEnvVar("openshift.router.host");
+    private int routerHttpPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "80"));
+    private int routerHttpsPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "443"));
+    private int routerSniPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "443"));
 
     public static CECubeConfiguration fromMap(final Map<String, String> props) {
         //XXX: need to rename arq.ce-cube properties.  arq extension properties cannot contain '.'
@@ -53,6 +56,10 @@ public class CECubeConfiguration extends Configuration {
         config.setNamespacePrefix(getProperty(props, "kubernetesNamespacePrefix", config.getNamespacePrefix()));
         config.setOpenshiftPassword(getProperty(props, "openshiftPassword", config.getOpenshiftPassword()));
         config.setOpenshiftUsername(getProperty(props, "openshiftUsername", config.getOpenshiftUsername()));
+        config.setRouterHost(getProperty(props, "routerHost", config.routerHost));
+        config.setRouterHttpPort(Integer.valueOf(getProperty(props, "routerHttpPort", Integer.toString(config.routerHttpPort))));
+        config.setRouterHttpsPort(Integer.valueOf(getProperty(props, "routerHttpsPort", Integer.toString(config.routerHttpsPort))));
+        config.setRouterSniPort(Integer.valueOf(getProperty(props, "routerSniPort", Integer.toString(config.routerSniPort))));
         config.setStartupTimeout(Long.valueOf(getProperty(props, "arquillianStartupTimeout", Long.toString(config.getStartupTimeout()))));
         config.setTemplateLabels(getProperty(props, "openshiftTemplateLabels", config.templateLabels));
         config.setTemplateParameters(getProperty(props, "openshiftTemplateParameters", config.templateParameters));
@@ -100,6 +107,42 @@ public class CECubeConfiguration extends Configuration {
 
     public void setTemplateProcess(boolean templateProcess) {
         this.templateProcess = templateProcess;
+    }
+
+    public String getRouterHost() {
+        return routerHost;
+    }
+
+    public void setRouterHost(String routerHost) {
+        this.routerHost = routerHost;
+    }
+
+    public int getRouterHttpPort() {
+        return routerHttpPort;
+    }
+
+    public void setRouterHttpPort(int routerHttpPort) {
+        this.routerHttpPort = routerHttpPort;
+    }
+
+    public int getRouterHttpsPort() {
+        return routerHttpsPort;
+    }
+
+    public void setRouterHttpsPort(int routerHttpsPort) {
+        this.routerHttpsPort = routerHttpsPort;
+    }
+
+    public int getRouterSniPort() {
+        return routerSniPort;
+    }
+
+    public void setRouterSniPort(int routerSniPort) {
+        this.routerSniPort = routerSniPort;
+    }
+
+    public static long getSerialversionuid() {
+        return serialVersionUID;
     }
 
     private static String getProperty(final Map<String, String> props, final String key, final String defaultValue) {

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
@@ -43,8 +43,8 @@ public class CECubeConfiguration extends Configuration {
     private boolean templateProcess = Boolean.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.template.process", "true"));
     private String routerHost = Strings.getSystemPropertyOrEnvVar("openshift.router.host");
     private int routerHttpPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "80"));
-    private int routerHttpsPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "443"));
-    private int routerSniPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "443"));
+    private int routerHttpsPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpsPort", "443"));
+    private int routerSniPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.sniPort", "443"));
 
     public static CECubeConfiguration fromMap(final Map<String, String> props) {
         //XXX: need to rename arq.ce-cube properties.  arq extension properties cannot contain '.'

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube;
+
+import java.util.Map;
+
+import org.jboss.arquillian.ce.utils.Configuration;
+import org.jboss.arquillian.ce.utils.Strings;
+import org.jboss.arquillian.container.spi.ConfigurationException;
+
+/**
+ * CECubeConfiguration
+ * <p/>
+ * Configuration for Cloud Enablement Arquillian Cube extension.
+ * 
+ * @author Rob Cernich
+ */
+public class CECubeConfiguration extends Configuration {
+    private static final long serialVersionUID = 1L;
+
+    private String templateURL = Strings.getSystemPropertyOrEnvVar("openshift.template.url");
+    private String templateLabels = Strings.getSystemPropertyOrEnvVar("openshift.template.labels");
+    private String templateParameters = Strings.getSystemPropertyOrEnvVar("openshift.template.parameters");
+    private boolean templateProcess = Boolean.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.template.process", "true"));
+
+    public static CECubeConfiguration fromMap(final Map<String, String> props) {
+        //XXX: need to rename arq.ce-cube properties.  arq extension properties cannot contain '.'
+        final CECubeConfiguration config = new CECubeConfiguration();
+        config.setApiVersion(getProperty(props, "kubernetesApiVersion", config.getApiVersion()));
+        config.setIgnoreCleanup(Boolean.valueOf(getProperty(props, "kubernetesIgnoreCleanup", Boolean.toString(config.isIgnoreCleanup()))));
+        config.setKubernetesMaster(getProperty(props, "kubernetesMaster", config.getKubernetesMaster()));
+        config.setNamespace(getProperty(props, "kubernetesNamespace", null));
+        config.setNamespacePrefix(getProperty(props, "kubernetesNamespacePrefix", config.getNamespacePrefix()));
+        config.setOpenshiftPassword(getProperty(props, "openshiftPassword", config.getOpenshiftPassword()));
+        config.setOpenshiftUsername(getProperty(props, "openshiftUsername", config.getOpenshiftUsername()));
+        config.setStartupTimeout(Long.valueOf(getProperty(props, "arquillianStartupTimeout", Long.toString(config.getStartupTimeout()))));
+        config.setTemplateLabels(getProperty(props, "openshiftTemplateLabels", config.templateLabels));
+        config.setTemplateParameters(getProperty(props, "openshiftTemplateParameters", config.templateParameters));
+        config.setTemplateProcess(Boolean.valueOf(getProperty(props, "openshiftTemplateProcess", Boolean.toString(config.templateProcess))));
+        config.setTemplateURL(getProperty(props, "openshiftTemplateUrl", config.templateURL));
+        config.setToken(getProperty(props, "kubernetesAuthToken", config.getToken()));
+        config.setTrustCerts(Boolean.valueOf(getProperty(props, "kubernetesTrustCerts", Boolean.toString(config.isTrustCerts()))));
+        config.loadApplications(props);
+        config.validate();
+        return config;
+    }
+    
+    private void loadApplications(Map<String, String> props) {
+        //TODO: parse application properties, e.g. templates, parms, env, role bindings, etc.
+        // this might replace @Template
+    }
+
+    public String getTemplateURL() {
+        return templateURL;
+    }
+
+    public void setTemplateURL(String templateURL) {
+        this.templateURL = templateURL;
+    }
+
+    public Map<String, String> getTemplateLabels() {
+        return Strings.splitKeyValueList(templateLabels);
+    }
+
+    public void setTemplateLabels(String templateLabels) {
+        this.templateLabels = templateLabels;
+    }
+
+    public Map<String, String> getTemplateParameters() {
+        return Strings.splitKeyValueList(templateParameters);
+    }
+
+    public void setTemplateParameters(String templateParameters) {
+        this.templateParameters = templateParameters;
+    }
+
+    public boolean isTemplateProcess() {
+        return templateProcess;
+    }
+
+    public void setTemplateProcess(boolean templateProcess) {
+        this.templateProcess = templateProcess;
+    }
+
+    private static String getProperty(final Map<String, String> props, final String key, final String defaultValue) {
+        final String value = props.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
+    }
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeInitializer.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeInitializer.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube;
+
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.ce.adapter.OpenShiftAdapter;
+import org.jboss.arquillian.ce.api.ConfigurationHandle;
+import org.jboss.arquillian.ce.fabric8.F8OpenShiftAdapter;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+/**
+ * CECubeInitializer
+ * <p/>
+ * Initializer for CE Arquillian Cube extension.
+ * 
+ * @author Rob Cernich
+ */
+public class CECubeInitializer {
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<ConfigurationHandle> configurationHandleProducer;
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<CECubeConfiguration> configurationProducer;
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<OpenShiftAdapter> openShiftAdapterProducer;
+
+    public void configure(@Observes ArquillianDescriptor arquillianDescriptor) {
+        // read in our configuration
+        CECubeConfiguration config = CECubeConfiguration.fromMap(arquillianDescriptor.extension("ce-cube")
+                .getExtensionProperties());
+        configurationProducer.set(config);
+        configurationHandleProducer.set(config);
+    }
+    
+    public void createOpenShiftAdapter(@Observes OpenShiftClient client, CECubeConfiguration configuration) {
+        openShiftAdapterProducer.set(new F8OpenShiftAdapter(client.getClientExt(), configuration));
+    }
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeOpenShiftExtension.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeOpenShiftExtension.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
  * contributors as indicated by the @author tags. All rights reserved.
  * See the copyright.txt in the distribution for a full listing of
  * individual contributors.
@@ -20,13 +20,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.arquillian.ce.cube;
 
-package org.jboss.arquillian.ce.shrinkwrap;
+import org.jboss.arquillian.core.spi.LoadableExtension;
 
-/**
- * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
- */
-public interface PomStrategy {
-    String[] profiles();
-    String toPom();
+public class CECubeOpenShiftExtension implements LoadableExtension {
+    public void register(ExtensionBuilder builder) {
+        builder.observer(CECubeInitializer.class)
+               .observer(CubeOpenShiftOverrider.class)
+               .observer(CEProjectManager.class)
+               .observer(CEEnvironmentProcessor.class)
+               .observer(CEApplicationHandler.class);
+    }
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -1,0 +1,281 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.ce.adapter.OpenShiftAdapter;
+import org.jboss.arquillian.ce.api.Replicas;
+import org.jboss.arquillian.ce.api.Template;
+import org.jboss.arquillian.ce.api.TemplateParameter;
+import org.jboss.arquillian.ce.proxy.Proxy;
+import org.jboss.arquillian.ce.resources.OpenShiftResourceFactory;
+import org.jboss.arquillian.ce.utils.Checker;
+import org.jboss.arquillian.ce.utils.Containers;
+import org.jboss.arquillian.ce.utils.ParamValue;
+import org.jboss.arquillian.ce.utils.StringResolver;
+import org.jboss.arquillian.ce.utils.Strings;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.arquillian.test.spi.annotation.ClassScoped;
+import org.jboss.arquillian.test.spi.event.suite.AfterClass;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+
+/**
+ * CEEnvironmentProcessor
+ * <p/>
+ * Temporary class to handle @Template and @OpenShiftResource annotations on
+ * test classes. Eventually, these will be migrated to Cube types, at which
+ * point this will delegate to those for setup/teardown (via
+ * StartCube/StopCube).
+ * 
+ * @author Rob Cernich
+ */
+public class CEEnvironmentProcessor {
+
+    private final Logger log = Logger.getLogger(CEEnvironmentProcessor.class.getName());
+    
+    public interface TemplateDetails {
+        public Map<String,String> getLabels();
+        public int getReplicas();
+    }
+
+    @Inject @ClassScoped
+    private InstanceProducer<TemplateDetails> templateDetailsProducer;
+
+    /**
+     * Create the environment as specified by @Template or
+     * arq.extension.ce-cube.openshift.template.* properties.
+     * 
+     * In the future, this might be handled by starting application Cube
+     * objects, e.g. CreateCube(application), StartCube(application)
+     * 
+     * Needs to fire before the containers are started.
+     */
+    public void createEnvironment(@Observes(precedence=10) BeforeClass event, OpenShiftAdapter client,
+            CECubeConfiguration configuration) throws DeploymentException {
+        final TestClass testClass = event.getTestClass();
+        log.info(String.format("Creating environment for %s", testClass.getName()));
+        OpenShiftResourceFactory.createResources(testClass.getName(), client, null, testClass.getJavaClass(),
+                configuration.getProperties());
+        processTemplate(testClass, client, configuration);
+    }
+
+    /**
+     * Wait for the template resources to come up after the test container has
+     * been started. This allows the test container and the template resources
+     * to come up in parallel.
+     */
+    public void waitForDeployments(@Observes(precedence = -100) BeforeDeploy event, OpenShiftAdapter client,
+            TemplateDetails details, TestClass testClass) throws Exception {
+        if (details == null) {
+            return;
+        }
+        log.info(String.format("Waiting for environment for %s", testClass.getName()));
+        try {
+            delay(client, details.getLabels(), details.getReplicas());
+        } catch (Throwable t) {
+            throw new DeploymentException("Error waiting for template resources to deploy: " + testClass.getName(), t);
+        }
+    }
+
+    /**
+     * Tear down the environment.
+     * 
+     * In the future, this might be handled by stopping application Cube
+     * objects, e.g. StopCube(application), DestroyCube(application).
+     */
+    public void deleteEnvironment(@Observes AfterClass event, OpenShiftAdapter client) throws Exception {
+        final TestClass testClass = event.getTestClass();
+        client.deleteTemplate(testClass.getName());
+        OpenShiftResourceFactory.deleteResources(testClass.getName(), client);
+    }
+
+    private void processTemplate(TestClass tc, OpenShiftAdapter client, CECubeConfiguration configuration)
+            throws DeploymentException {
+        final StringResolver resolver = Strings.createStringResolver(configuration.getProperties());
+        final Template template = tc.getAnnotation(Template.class);
+        final String templateURL = readTemplateUrl(template, configuration, resolver);
+        try {
+            final int replicas = readReplicas(tc);
+            final Map<String, String> labels = readLabels(template, configuration, resolver);
+            if (labels.isEmpty()) {
+                log.warning(String.format("Empty labels for template: %s, namespace: %s", templateURL,
+                        configuration.getNamespace()));
+            }
+
+            if (executeProcessTemplate(template, configuration)) {
+                List<ParamValue> values = new ArrayList<>();
+                addParameterValues(values, readParameters(template, configuration, resolver), false);
+                addParameterValues(values, System.getenv(), true);
+                addParameterValues(values, System.getProperties(), true);
+                values.add(new ParamValue("REPLICAS", String.valueOf(replicas))); // not
+                                                                                  // yet
+                                                                                  // supported
+
+                log.info(String.format("Applying OpenShift template: %s", templateURL));
+                // use old archive name as templateKey
+                client.processTemplateAndCreateResources(tc.getName(), templateURL, values);
+            } else {
+                log.info(String.format("Ignoring template [%s] processing ...", templateURL));
+            }
+
+            templateDetailsProducer.set(new TemplateDetails() {
+                
+                @Override
+                public int getReplicas() {
+                    return replicas;
+                }
+                
+                @Override
+                public Map<String, String> getLabels() {
+                    return labels;
+                }
+            });
+        } catch (Throwable t) {
+            throw new DeploymentException("Cannot deploy template: " + templateURL, t);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked" })
+    private void addParameterValues(List<ParamValue> values, Map map, boolean filter) {
+        Set<Map.Entry> entries = map.entrySet();
+        for (Map.Entry env : entries) {
+            if (env.getKey() instanceof String && env.getValue() instanceof String) {
+                String key = (String) env.getKey();
+                if (filter == false || key.startsWith("ARQ_") || key.startsWith("arq_")) {
+                    if (filter) {
+                        values.add(new ParamValue(key.substring("ARQ_".length()), (String) env.getValue()));
+                    } else {
+                        values.add(new ParamValue(key, (String) env.getValue()));
+                    }
+                }
+            }
+        }
+    }
+
+    private String readTemplateUrl(Template template, CECubeConfiguration configuration, StringResolver resolver) {
+        String templateUrl = template == null ? null : template.url();
+        if (templateUrl == null || templateUrl.length() == 0) {
+            templateUrl = resolver.resolve(configuration.getTemplateURL());
+        }
+
+        if (templateUrl == null) {
+            throw new IllegalArgumentException(
+                    "Missing template URL! Either add @Template to your test or add -Dopenshift.template.url=<url>");
+        }
+
+        return templateUrl;
+    }
+
+    private int readReplicas(TestClass testClass) {
+        Replicas replicas = testClass.getAnnotation(Replicas.class);
+        int r = -1;
+        if (replicas != null) {
+            if (replicas.value() <= 0) {
+                throw new IllegalArgumentException("Non-positive replicas size: " + replicas.value());
+            }
+            r = replicas.value();
+        }
+        int max = 0;
+        for (Method c : testClass.getMethods(TargetsContainer.class)) {
+            int index = Strings.parseNumber(c.getAnnotation(TargetsContainer.class).value());
+            if (r > 0 && index >= r) {
+                throw new IllegalArgumentException(String.format(
+                        "Node / pod index bigger then replicas; %s >= %s ! (%s)", index, r, c));
+            }
+            max = Math.max(max, index);
+        }
+        if (r < 0) {
+            return max + 1;
+        } else {
+            return r;
+        }
+    }
+
+    private Map<String, String> readLabels(Template template, CECubeConfiguration configuration, StringResolver resolver) {
+        if (template != null) {
+            String string = template.labels();
+            if (string != null && string.length() > 0) {
+                Map<String, String> map = Strings.splitKeyValueList(string);
+                Map<String, String> resolved = new HashMap<>();
+                for (Map.Entry<String, String> entry : map.entrySet()) {
+                    resolved.put(resolver.resolve(entry.getKey()), resolver.resolve(entry.getValue()));
+                }
+                return resolved;
+            }
+        }
+        return configuration.getTemplateLabels();
+    }
+
+    private boolean executeProcessTemplate(Template template, CECubeConfiguration configuration) {
+        return (template == null || template.process()) && configuration.isTemplateProcess();
+    }
+
+    private Map<String, String> readParameters(Template template, CECubeConfiguration configuration,
+            StringResolver resolver) {
+        if (template != null) {
+            TemplateParameter[] parameters = template.parameters();
+            Map<String, String> map = new HashMap<>();
+            for (TemplateParameter parameter : parameters) {
+                String name = resolver.resolve(parameter.name());
+                String value = resolver.resolve(parameter.value());
+                map.put(name, value);
+            }
+            return map;
+        }
+        return configuration.getTemplateParameters();
+    }
+
+    private void delay(OpenShiftAdapter client, final Map<String, String> labels, final int replicas) throws Exception {
+        final Proxy proxy = client.createProxy();
+        Containers.delay(client.getConfiguration().getStartupTimeout(), 4000L, new Checker() {
+            public boolean check() {
+                Set<String> pods = proxy.getReadyPods(labels);
+                boolean result = (pods.size() >= replicas);
+                if (result) {
+                    log.info(String.format("Pods are ready: %s", pods));
+                }
+                return result;
+            }
+
+            @Override
+            public String toString() {
+                return String.format("(Required pods: %s)", replicas);
+            }
+        });
+    }
+
+
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.ce.resources.OpenShiftResourceFactory;
 import org.jboss.arquillian.ce.utils.Checker;
 import org.jboss.arquillian.ce.utils.Containers;
 import org.jboss.arquillian.ce.utils.ParamValue;
+import org.jboss.arquillian.ce.utils.ReflectionUtils;
 import org.jboss.arquillian.ce.utils.StringResolver;
 import org.jboss.arquillian.ce.utils.Strings;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
@@ -125,7 +126,7 @@ public class CEEnvironmentProcessor {
     private void processTemplate(TestClass tc, OpenShiftAdapter client, CECubeConfiguration configuration)
             throws DeploymentException {
         final StringResolver resolver = Strings.createStringResolver(configuration.getProperties());
-        final Template template = tc.getAnnotation(Template.class);
+        final Template template = ReflectionUtils.findAnnotation(tc.getJavaClass(), Template.class);
         final String templateURL = readTemplateUrl(template, configuration, resolver);
         try {
             final int replicas = readReplicas(tc);

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -105,7 +105,7 @@ public class CEEnvironmentProcessor {
             return;
         }
         if (details == null) {
-            log.warning(String.format("No environment for environment for %s", testClass.getName()));
+            log.warning(String.format("No environment for %s", testClass.getName()));
             return;
         }
         log.info(String.format("Waiting for environment for %s", testClass.getName()));

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -43,7 +43,7 @@ import org.jboss.arquillian.ce.utils.ReflectionUtils;
 import org.jboss.arquillian.ce.utils.StringResolver;
 import org.jboss.arquillian.ce.utils.Strings;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
-import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
+import org.jboss.arquillian.container.spi.event.container.AfterStart;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -98,9 +98,14 @@ public class CEEnvironmentProcessor {
      * been started. This allows the test container and the template resources
      * to come up in parallel.
      */
-    public void waitForDeployments(@Observes(precedence = -100) BeforeDeploy event, OpenShiftAdapter client,
+    public void waitForDeployments(@Observes(precedence = -100) AfterStart event, OpenShiftAdapter client,
             TemplateDetails details, TestClass testClass) throws Exception {
+        if (testClass == null) {
+            // nothing to do, since we're not in ClassScoped context
+            return;
+        }
         if (details == null) {
+            log.warning(String.format("No environment for environment for %s", testClass.getName()));
             return;
         }
         log.info(String.format("Waiting for environment for %s", testClass.getName()));
@@ -119,6 +124,7 @@ public class CEEnvironmentProcessor {
      */
     public void deleteEnvironment(@Observes AfterClass event, OpenShiftAdapter client) throws Exception {
         final TestClass testClass = event.getTestClass();
+        log.info(String.format("Deleting environment for environment for %s", testClass.getName()));
         client.deleteTemplate(testClass.getName());
         OpenShiftResourceFactory.deleteResources(testClass.getName(), client);
     }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEProjectManager.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEProjectManager.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube;
+
+import io.fabric8.openshift.api.model.DoneableProjectRequest;
+import io.fabric8.openshift.api.model.Project;
+
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+
+/**
+ * CEProjectManager
+ * <p/>
+ * Manages the test project, creating it if need be and cleaning up afterward.
+ * 
+ * @author Rob Cernich
+ */
+public class CEProjectManager {
+    private Project createdProject;
+
+    /**
+     * If we're creating the project used to run the tests, we need to do that
+     * before Arquillian Cube starts registering Cube objects, so this needs to
+     * be invoked prior to CubeOpenShiftRegistrar, but after the OpenShiftClient
+     * has been created.
+     * 
+     * TODO: consider creating a new project for each test case.
+     * 
+     * @param client
+     * @param config
+     */
+    public void createProject(@Observes(precedence = 10) OpenShiftClient client, CECubeConfiguration config) {
+        Project existing = null;;
+        try {
+            existing = client.getClientExt().projects().withName(config.getNamespace()).get();
+        } catch (Exception e) {
+            // f8 barfs if it receives 403 when using auth tokens as it tries to intercept and use null uid/pwd.
+        }
+        if (existing == null) {
+            DoneableProjectRequest projectRequest = client.getClientExt().projectrequests().createNew();
+            projectRequest.withDescription("auto-generated project for arquillian testing").withNewMetadata()
+                    .withName(config.getNamespace())
+                    .endMetadata();
+            projectRequest.done();
+            createdProject = client.getClientExt().projects().withName(config.getNamespace()).get();
+        }
+    }
+
+    /**
+     * Clean up after ourselves. This needs to be invoked before the
+     * OpenShiftClient is closed.
+     * 
+     * @param event
+     * @param client
+     * @param config
+     */
+    public void deleteProject(@Observes(precedence = -100) AfterSuite event, OpenShiftClient client,
+            CECubeConfiguration config) {
+        if (createdProject != null && config.performCleanup()) {
+            client.getClientExt().projects().withName(createdProject.getMetadata().getName()).delete();
+            createdProject = null;
+        }
+    }
+
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CubeOpenShiftOverrider.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CubeOpenShiftOverrider.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+/**
+ * CubeOpenShiftOverrider
+ * <p/>
+ * Processes overrides for Arquillian Cube OpenShift extension.
+ * 
+ * @author Rob Cernich
+ */
+public class CubeOpenShiftOverrider {
+
+    /**
+     * Override values used to initialize CubeOpenShiftConfiguration so we're
+     * all on the same page.
+     * 
+     * @param config
+     * @param arquillianDescriptor
+     */
+    public void overrideCubeOpenShiftConfiguration(@Observes CECubeConfiguration config,
+            ArquillianDescriptor arquillianDescriptor) {
+        final ExtensionDef cubeOpenShiftExtension = arquillianDescriptor.extension("openshift");
+        cubeOpenShiftExtension.property("originServer", config.getKubernetesMaster());
+        cubeOpenShiftExtension.property("namespace", config.getNamespace());
+        // might look at setting definitions here, although i'm not sure how
+        // this will work if we need to do template processing
+        // cubeOpenShiftExtension.property("definitions", getDefinitions());
+    }
+
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/RouteURL.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/RouteURL.java
@@ -22,18 +22,31 @@
  */
 package org.jboss.arquillian.ce.cube;
 
-import org.jboss.arquillian.ce.cube.enrichers.RouteURLEnricher;
-import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.test.spi.TestEnricher;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-public class CECubeOpenShiftExtension implements LoadableExtension {
-    public void register(ExtensionBuilder builder) {
-        builder.observer(CECubeInitializer.class)
-               .observer(CubeOpenShiftOverrider.class)
-               .observer(CEProjectManager.class)
-               .observer(CEEnvironmentProcessor.class)
-               .observer(CEApplicationHandler.class);
-        
-        builder.service(TestEnricher.class, RouteURLEnricher.class);
-    }
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * OpenShiftRouter
+ * <p/>
+ * Used with @ArquillianResource URL objects. Provides a URL to the OpenShift
+ * router configured on the ce-cube extension, e.g.
+ * arq.extension.ce-cube.openShiftRouterIP, setting the hostname appropriately.
+ * 
+ * @author Rob Cernich
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER })
+public @interface RouteURL {
+    /**
+     * @return the route name
+     */
+    String value() default "";
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameService.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameService.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube.dns;
+
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteList;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Set;
+
+import sun.net.spi.nameservice.NameService;
+
+/**
+ * CENameService
+ * 
+ * @author Rob Cernich
+ */
+public class CENameService implements NameService {
+
+    private static Set<String> hosts = new HashSet<String>();
+    private static InetAddress[] routerAddr = new InetAddress[1];
+
+    public static void setRoutes(RouteList routeList, String routerHost) {
+        synchronized (hosts) {
+            hosts.clear();
+            try {
+                CENameService.routerAddr[0] = routerHost == null ? null : InetAddress.getByName(routerHost);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid IP for router host", e);
+            }
+            if (routeList == null) {
+                return;
+            }
+            for (Route route : routeList.getItems()) {
+                final String routeHostname = route.getSpec().getHost();
+                System.out.println(String.format("Adding route to name service: %s %s", routerHost, routeHostname));
+                hosts.add(routeHostname);
+            }
+        }
+    }
+
+    @Override
+    public InetAddress[] lookupAllHostAddr(String host) throws UnknownHostException {
+        synchronized (hosts) {
+            if (routerAddr[0] != null && hosts.contains(host)) {
+                return routerAddr;
+            }
+            throw new UnknownHostException(host);
+        }
+    }
+
+    @Override
+    public String getHostByAddr(byte[] addr) throws UnknownHostException {
+        throw new UnknownHostException();
+    }
+
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameService.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameService.java
@@ -40,13 +40,13 @@ import sun.net.spi.nameservice.NameService;
 public class CENameService implements NameService {
 
     private static Set<String> hosts = new HashSet<String>();
-    private static InetAddress[] routerAddr = new InetAddress[1];
+    private static InetAddress routerAddr;
 
     public static void setRoutes(RouteList routeList, String routerHost) {
         synchronized (hosts) {
             hosts.clear();
             try {
-                CENameService.routerAddr[0] = routerHost == null ? null : InetAddress.getByName(routerHost);
+                CENameService.routerAddr = routerHost == null ? null : InetAddress.getByName(routerHost);
             } catch (UnknownHostException e) {
                 throw new IllegalArgumentException("Invalid IP for router host", e);
             }
@@ -64,8 +64,8 @@ public class CENameService implements NameService {
     @Override
     public InetAddress[] lookupAllHostAddr(String host) throws UnknownHostException {
         synchronized (hosts) {
-            if (routerAddr[0] != null && hosts.contains(host)) {
-                return routerAddr;
+            if (routerAddr != null && hosts.contains(host)) {
+                return new InetAddress[] {InetAddress.getByAddress(host, routerAddr.getAddress()) };
             }
             throw new UnknownHostException(host);
         }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameServiceDescriptor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/dns/CENameServiceDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube.dns;
+
+import sun.net.spi.nameservice.NameService;
+import sun.net.spi.nameservice.NameServiceDescriptor;
+
+/**
+ * CENameServiceDescriptor
+ * <p/>
+ * Descriptor for OpenShift Route NameService.
+ * 
+ * @author Rob Cernich
+ */
+public class CENameServiceDescriptor implements NameServiceDescriptor {
+
+    @Override
+    public NameService createNameService() throws Exception {
+        return new CENameService();
+    }
+
+    @Override
+    public String getProviderName() {
+        return "CEArquillianNameService";
+    }
+
+    @Override
+    public String getType() {
+        return "dns";
+    }
+
+}

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/OpenShiftAdapterResourceProvider.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/OpenShiftAdapterResourceProvider.java
@@ -20,23 +20,36 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ce.cube;
+package org.jboss.arquillian.ce.cube.enrichers;
 
-import org.jboss.arquillian.ce.cube.enrichers.OpenShiftAdapterResourceProvider;
-import org.jboss.arquillian.ce.cube.enrichers.RouteURLEnricher;
-import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.test.spi.TestEnricher;
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.ce.adapter.OpenShiftAdapter;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-public class CECubeOpenShiftExtension implements LoadableExtension {
-    public void register(ExtensionBuilder builder) {
-        builder.observer(CECubeInitializer.class)
-               .observer(CubeOpenShiftOverrider.class)
-               .observer(CEProjectManager.class)
-               .observer(CEEnvironmentProcessor.class)
-               .observer(CEApplicationHandler.class);
-        
-        builder.service(TestEnricher.class, RouteURLEnricher.class)
-               .service(ResourceProvider.class, OpenShiftAdapterResourceProvider.class);
+/**
+ * OpenShiftAdapterResourceProvider
+ * 
+ * @author Rob Cernich
+ */
+public class OpenShiftAdapterResourceProvider implements ResourceProvider {
+
+    @Inject
+    @ApplicationScoped
+    private Instance<OpenShiftAdapter> openshiftAdapterInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return type.isAssignableFrom(OpenShiftAdapter.class);
     }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return openshiftAdapterInstance.get();
+    }
+
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/RouteURLEnricher.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/RouteURLEnricher.java
@@ -24,30 +24,11 @@ package org.jboss.arquillian.ce.cube.enrichers;
 
 import io.fabric8.openshift.api.model.Route;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.Socket;
 import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLStreamHandler;
-import java.net.UnknownHostException;
-import java.security.cert.X509Certificate;
-import java.util.Collections;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SNIHostName;
-import javax.net.ssl.SNIServerName;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import org.arquillian.cube.impl.util.ReflectionUtil;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
@@ -135,104 +116,10 @@ public class RouteURLEnricher implements TestEnricher {
             port = config.getRouterHttpsPort();
         }
         try {
-            return new URL(protocol, host, port, "/", new URLStreamHandler() {
-                @Override
-                protected URLConnection openConnection(URL u) throws IOException {
-                    final URLConnection connection = new URL(u.toString()).openConnection();
-                    configureHostname(connection, routeHostname);
-                    return connection;
-                }
-
-                @Override
-                protected URLConnection openConnection(URL u, Proxy p) throws IOException {
-                    final URLConnection connection = new URL(u.toString()).openConnection(p);
-                    configureHostname(connection, routeHostname);
-                    return connection;
-                }
-            });
+            return new URL(protocol, routeHostname, port, "/");
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Unable to create route URL", e);
         }
     }
 
-    private void configureHostname(final URLConnection connection, final String routeHostname) throws IOException {
-        try {
-            connection.setRequestProperty("Host", routeHostname);
-            if (connection instanceof HttpsURLConnection) {
-                final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
-                TrustManager[] trustAllCerts = new TrustManager[] {new X509TrustManager() {
-                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                        return null;
-                    }
-
-                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                    }
-
-                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                    }
-                } };
-                // Install the all-trusting trust manager
-                final SSLContext sc = SSLContext.getInstance("SSL");
-                sc.init(null, trustAllCerts, new java.security.SecureRandom());
-                httpsConnection.setSSLSocketFactory(new DelegatingSSLSocketFactory(sc.getSocketFactory(), routeHostname));
-            }
-        } catch (Exception e) {
-            throw new IOException("Error configuring hostname on connection", e);
-        }
-    }
-    
-    private static final class DelegatingSSLSocketFactory extends SSLSocketFactory {
-        private final SSLSocketFactory delegate;
-        private final String hostname;
-        
-        private DelegatingSSLSocketFactory(final SSLSocketFactory delegate, final String hostname) {
-            this.delegate = delegate;
-            this.hostname = hostname;
-        }
-        
-        @Override
-        public String[] getDefaultCipherSuites() {
-            return delegate.getDefaultCipherSuites();
-        }
-
-        @Override
-        public String[] getSupportedCipherSuites() {
-            return delegate.getSupportedCipherSuites();
-        }
-
-        @Override
-        public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
-            return overrideHostname(delegate.createSocket(s, host, port, autoClose));
-        }
-
-        @Override
-        public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
-            return overrideHostname(delegate.createSocket(host, port));
-        }
-
-        @Override
-        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException,
-                UnknownHostException {
-            return overrideHostname(delegate.createSocket(host, port, localHost, localPort));
-        }
-
-        @Override
-        public Socket createSocket(InetAddress host, int port) throws IOException {
-            return overrideHostname(delegate.createSocket(host, port));
-        }
-
-        @Override
-        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
-                throws IOException {
-            return overrideHostname(delegate.createSocket(address, port, localAddress, localPort));
-        }
-        
-        private Socket overrideHostname(final Socket socket) {
-            final SSLSocket sslSocket = (SSLSocket) socket;
-            final SSLParameters params = sslSocket.getSSLParameters();
-            params.setServerNames(Collections.<SNIServerName>singletonList(new SNIHostName(hostname)));
-            sslSocket.setSSLParameters(params);
-            return sslSocket;
-        }
-    }
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/RouteURLEnricher.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/enrichers/RouteURLEnricher.java
@@ -1,0 +1,238 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.ce.cube.enrichers;
+
+import io.fabric8.openshift.api.model.Route;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.UnknownHostException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.ce.cube.CECubeConfiguration;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+/**
+ * RouteProxyProvider
+ * 
+ * @author Rob Cernich
+ */
+public class RouteURLEnricher implements TestEnricher {
+
+    @Inject
+    private Instance<OpenShiftClient> clientInstance;
+
+    @Inject
+    private Instance<CECubeConfiguration> configurationInstance;
+
+    @Override
+    public void enrich(Object testCase) {
+        for (Field field : ReflectionUtil.getFieldsWithAnnotation(testCase.getClass(), RouteURL.class)) {
+            try {
+                if (!field.isAccessible()) {
+                    field.setAccessible(true);
+                }
+                field.set(testCase, lookup(getRouteURLAnnotation(field.getAnnotations())));
+            } catch (Exception e) {
+                throw new RuntimeException("Could not set RoutURL value on field " + field);
+            }
+        }
+    }
+
+    @Override
+    public Object[] resolve(Method method) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            RouteURL routeURL = getRouteURLAnnotation(method.getParameterAnnotations()[i]);
+            if (routeURL != null) {
+                values[i] = lookup(routeURL);
+            }
+        }
+        return values;
+    }
+
+    private RouteURL getRouteURLAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType() == RouteURL.class) {
+                return (RouteURL) annotation;
+            }
+        }
+        return null;
+    }
+
+    private URL lookup(RouteURL routeURL) {
+        if (routeURL == null) {
+            throw new NullPointerException("RouteURL is null!");
+        }
+        final String routeName = routeURL.value();
+        if (routeName == null || routeName.length() == 0) {
+            throw new IllegalArgumentException("Must specify a route name!");
+        }
+        final CECubeConfiguration config = configurationInstance.get();
+        final String host = config.getRouterHost();
+        if (host == null || host.length() == 0) {
+            throw new IllegalArgumentException("Must specify routerHost!");
+        }
+        final OpenShiftClient client = clientInstance.get();
+        final Route route = client.getClientExt().routes().inNamespace(config.getNamespace()).withName(routeName).get();
+        if (route == null) {
+            throw new IllegalArgumentException("Could not resolve route: " + routeName);
+        }
+        final String routeHostname = route.getSpec().getHost();
+        final String protocol;
+        final int port;
+        if (route.getSpec().getTls() == null) {
+            protocol = "http";
+            port = config.getRouterHttpPort();
+        } else {
+            protocol = "https";
+            port = config.getRouterHttpsPort();
+        }
+        try {
+            return new URL(protocol, host, port, "/", new URLStreamHandler() {
+                @Override
+                protected URLConnection openConnection(URL u) throws IOException {
+                    final URLConnection connection = new URL(u.toString()).openConnection();
+                    configureHostname(connection, routeHostname);
+                    return connection;
+                }
+
+                @Override
+                protected URLConnection openConnection(URL u, Proxy p) throws IOException {
+                    final URLConnection connection = new URL(u.toString()).openConnection(p);
+                    configureHostname(connection, routeHostname);
+                    return connection;
+                }
+            });
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Unable to create route URL", e);
+        }
+    }
+
+    private void configureHostname(final URLConnection connection, final String routeHostname) throws IOException {
+        try {
+            connection.setRequestProperty("Host", routeHostname);
+            if (connection instanceof HttpsURLConnection) {
+                final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+                TrustManager[] trustAllCerts = new TrustManager[] {new X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                    }
+
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
+                } };
+                // Install the all-trusting trust manager
+                final SSLContext sc = SSLContext.getInstance("SSL");
+                sc.init(null, trustAllCerts, new java.security.SecureRandom());
+                httpsConnection.setSSLSocketFactory(new DelegatingSSLSocketFactory(sc.getSocketFactory(), routeHostname));
+            }
+        } catch (Exception e) {
+            throw new IOException("Error configuring hostname on connection", e);
+        }
+    }
+    
+    private static final class DelegatingSSLSocketFactory extends SSLSocketFactory {
+        private final SSLSocketFactory delegate;
+        private final String hostname;
+        
+        private DelegatingSSLSocketFactory(final SSLSocketFactory delegate, final String hostname) {
+            this.delegate = delegate;
+            this.hostname = hostname;
+        }
+        
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return delegate.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+            return overrideHostname(delegate.createSocket(s, host, port, autoClose));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+            return overrideHostname(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException,
+                UnknownHostException {
+            return overrideHostname(delegate.createSocket(host, port, localHost, localPort));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return overrideHostname(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            return overrideHostname(delegate.createSocket(address, port, localAddress, localPort));
+        }
+        
+        private Socket overrideHostname(final Socket socket) {
+            final SSLSocket sslSocket = (SSLSocket) socket;
+            final SSLParameters params = sslSocket.getSSLParameters();
+            params.setServerNames(Collections.<SNIServerName>singletonList(new SNIHostName(hostname)));
+            sslSocket.setSSLParameters(params);
+            return sslSocket;
+        }
+    }
+}

--- a/cube/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/cube/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.ce.cube.CECubeOpenShiftExtension

--- a/cube/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
+++ b/cube/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
@@ -1,0 +1,1 @@
+org.jboss.arquillian.ce.cube.dns.CENameServiceDescriptor

--- a/eap6/pom.xml
+++ b/eap6/pom.xml
@@ -17,7 +17,7 @@
     <description>Cloud Enablement integrations for EAP6</description>
 
     <properties>
-        <version.eap>7.5.6.Final-redhat-SNAPSHOT</version.eap>
+        <version.eap>7.5.5.Final-redhat-3</version.eap>
     </properties>
 
     <dependencies>

--- a/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
+++ b/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
@@ -23,19 +23,6 @@
 
 package org.jboss.arquillian.ce.fabric8;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
@@ -66,9 +53,24 @@ import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.WebHookTriggerBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.fabric8.openshift.client.ParameterValue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.jboss.arquillian.ce.adapter.AbstractOpenShiftAdapter;
 import org.jboss.arquillian.ce.api.MountSecret;
 import org.jboss.arquillian.ce.portfwd.PortForwardContext;
@@ -87,7 +89,7 @@ import org.jboss.dmr.ModelNode;
 public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
     private final static Logger log = Logger.getLogger(F8OpenShiftAdapter.class.getName());
 
-    private final CeOpenShiftClient client;
+    private final OpenShiftClient client;
     private Map<String, KubernetesList> templates = new ConcurrentHashMap<>();
 
     static OpenShiftConfig toOpenShiftConfig(Configuration configuration) {
@@ -112,6 +114,11 @@ public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
     public F8OpenShiftAdapter(Configuration configuration) {
         super(configuration);
         this.client = create(configuration);
+    }
+
+    public F8OpenShiftAdapter(OpenShiftClient client, Configuration configuration) {
+        super(configuration);
+        this.client = client;
     }
 
     public Proxy createProxy() {

--- a/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8Proxy.java
+++ b/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8Proxy.java
@@ -23,28 +23,32 @@
 
 package org.jboss.arquillian.ce.fabric8;
 
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.Adapters;
+import io.fabric8.kubernetes.client.internal.SSLUtils;
+import io.fabric8.openshift.client.OpenShiftClient;
+
 import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 
-import com.squareup.okhttp.OkHttpClient;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodCondition;
-import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.client.internal.SSLUtils;
 import org.jboss.arquillian.ce.proxy.AbstractProxy;
 import org.jboss.arquillian.ce.utils.Configuration;
 import org.jboss.arquillian.ce.utils.OkHttpClientUtils;
+
+import com.squareup.okhttp.OkHttpClient;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public class F8Proxy extends AbstractProxy<Pod> {
-    private final CeOpenShiftClient client;
+    private final OpenShiftClient client;
     private OkHttpClient httpClient;
 
-    public F8Proxy(Configuration configuration, CeOpenShiftClient client) {
+    public F8Proxy(Configuration configuration, OpenShiftClient client) {
         super(configuration);
         this.client = client;
     }
@@ -59,7 +63,7 @@ public class F8Proxy extends AbstractProxy<Pod> {
 
     protected synchronized OkHttpClient getHttpClient() {
         if (httpClient == null) {
-            OkHttpClient okHttpClient = client.getHttpClient();
+            OkHttpClient okHttpClient = Adapters.get(OkHttpClient.class).adapt(client);
             OkHttpClientUtils.applyCookieHandler(okHttpClient);
             httpClient = okHttpClient;
         }

--- a/mgmtclient/pom.xml
+++ b/mgmtclient/pom.xml
@@ -17,7 +17,7 @@
     <description>Cloud Enablement integrations for EAP Management Client</description>
 
     <properties>
-        <version.eap>7.5.6.Final-redhat-SNAPSHOT</version.eap>
+        <version.eap>7.5.5.Final-redhat-3</version.eap>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <version.surefire.plugin>2.12.1</version.surefire.plugin>
         <version.dmr>1.2.0.Final</version.dmr>
         <version.javax.ejb>1.0.0.Final</version.javax.ejb>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
     </properties>
 
     <modules>
@@ -229,6 +231,34 @@
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-java</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <!-- Requires Java 8 for SNI patching -->
+                                    <requireJavaVersion>
+                                        <version>[1.8.0,)</version>
+                                    </requireJavaVersion>
+                                </rules>    
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 
     <!-- Properties -->
     <properties>
-        <version.arquillian>1.1.9.Final</version.arquillian>
+        <version.arquillian>1.1.11.Final</version.arquillian>
         <version.dockerjava>2.1.3</version.dockerjava>
         <version.http-client>2.6.0</version.http-client>
         <version.openshift.client>3.0.1.Final</version.openshift.client>
-        <version.fabric8>2.2.72</version.fabric8>
+        <version.fabric8>2.2.80</version.fabric8>
         <version.fabric8.client>1.3.63</version.fabric8.client>
         <version.jgit>4.1.0.201509280440-r</version.jgit>
         <version.jackson>2.6.3</version.jackson>
@@ -47,6 +47,7 @@
         <module>web</module>
         <module>wildfly</module>
         <module>template</module>
+        <module>cube</module>
     </modules>
 
     <!-- Maven 2 Repositories -->

--- a/shrinkwrap/src/main/java/org/jboss/arquillian/ce/shrinkwrap/Libraries.java
+++ b/shrinkwrap/src/main/java/org/jboss/arquillian/ce/shrinkwrap/Libraries.java
@@ -33,6 +33,15 @@ import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 public class Libraries {
     public static final PomStrategy MAVEN = new PomStrategy() {
         @Override
+        public String[] profiles() {
+            final String profiles = System.getProperty("cearq.maven.profiles");
+            if (profiles == null) {
+                return null;
+            }
+            return profiles.split(",");
+        }
+
+        @Override
         public String toPom() {
             return "pom.xml";
         }
@@ -43,7 +52,7 @@ public class Libraries {
     }
 
     public static File[] single(PomStrategy pomStrategy, String groupId, String artifactId) {
-        return Maven.resolver().loadPomFromFile(pomStrategy.toPom()).resolve(groupId + ":" + artifactId).withoutTransitivity().asFile();
+        return Maven.resolver().loadPomFromFile(pomStrategy.toPom(), pomStrategy.profiles()).resolve(groupId + ":" + artifactId).withoutTransitivity().asFile();
     }
 
     public static File[] transitive(String groupId, String artifactId) {
@@ -51,6 +60,6 @@ public class Libraries {
     }
 
     public static File[] transitive(PomStrategy pomStrategy, String groupId, String artifactId) {
-        return Maven.resolver().loadPomFromFile(pomStrategy.toPom()).resolve(groupId + ":" + artifactId).withTransitivity().asFile();
+        return Maven.resolver().loadPomFromFile(pomStrategy.toPom(), pomStrategy.profiles()).resolve(groupId + ":" + artifactId).withTransitivity().asFile();
     }
 }

--- a/utils/src/main/java/org/jboss/arquillian/ce/adapter/AbstractOpenShiftAdapter.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/adapter/AbstractOpenShiftAdapter.java
@@ -78,4 +78,9 @@ public abstract class AbstractOpenShiftAdapter implements OpenShiftAdapter {
         addResourceHandle(resourcesKey, handle);
         return handle;
     }
+    
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
 }

--- a/utils/src/main/java/org/jboss/arquillian/ce/adapter/OpenShiftAdapter.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/adapter/OpenShiftAdapter.java
@@ -35,6 +35,7 @@ import org.jboss.arquillian.ce.utils.Configuration;
 import org.jboss.arquillian.ce.utils.ParamValue;
 import org.jboss.arquillian.ce.utils.RCContext;
 import org.jboss.arquillian.ce.utils.RegistryLookup;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
@@ -66,6 +67,8 @@ public interface OpenShiftAdapter extends Closeable, RegistryLookup {
     Object addRoleBinding(String resourcesKey, String roleRefName, String userName);
 
     Object getService(String namespace, String serviceName);
+
+    void scaleDeployment(String name, int replicas) throws DeploymentException;
 
     void cleanReplicationControllers(String... ids) throws Exception;
 

--- a/utils/src/main/java/org/jboss/arquillian/ce/adapter/OpenShiftAdapter.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/adapter/OpenShiftAdapter.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.jboss.arquillian.ce.portfwd.PortForwardContext;
 import org.jboss.arquillian.ce.proxy.Proxy;
+import org.jboss.arquillian.ce.utils.Configuration;
 import org.jboss.arquillian.ce.utils.ParamValue;
 import org.jboss.arquillian.ce.utils.RCContext;
 import org.jboss.arquillian.ce.utils.RegistryLookup;
@@ -69,4 +70,6 @@ public interface OpenShiftAdapter extends Closeable, RegistryLookup {
     void cleanReplicationControllers(String... ids) throws Exception;
 
     void cleanPods(Map<String, String> labels) throws Exception;
+    
+    Configuration getConfiguration();
 }

--- a/utils/src/main/java/org/jboss/arquillian/ce/resources/OpenShiftResourceFactory.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/resources/OpenShiftResourceFactory.java
@@ -115,6 +115,14 @@ public class OpenShiftResourceFactory {
         }
     }
 
+    public static void deleteResources(String resourcesKey, OpenShiftAdapter adapter) {
+        try {
+            adapter.deleteResources(resourcesKey);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     private static abstract class Finder<U extends Annotation, V extends Annotation> {
 
         protected abstract Class<U> getWrapperType();

--- a/utils/src/main/java/org/jboss/arquillian/ce/utils/Configuration.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/utils/Configuration.java
@@ -50,7 +50,7 @@ public abstract class Configuration implements ContainerConfiguration, Configura
     private String openshiftPassword = getSystemPropertyOrEnvVar("openshift.password", "admin");
 
     private String apiVersion = getSystemPropertyOrEnvVar("kubernetes.api.version", "v1");
-    private String namespacePrefix = getSystemPropertyOrEnvVar("kubernetes.namespace.prefix");
+    private String namespacePrefix = getSystemPropertyOrEnvVar("kubernetes.namespace.prefix", "cearq");
     private String namespace = getSystemPropertyOrEnvVar("kubernetes.namespace");
     private String token = getSystemPropertyOrEnvVar("kubernetes.auth.token");
     private boolean trustCerts = Boolean.valueOf(getSystemPropertyOrEnvVar("kubernetes.trust.certs", "true"));


### PR DESCRIPTION
Replaced RunInPod, CETemplateExtension, ExternalDeployment, eap and wildfly containers with arquillian-cube functionality.  Added new project arquillian-ce-cube provides support for creating the test project and installing the test environment.  This new project also configures certain details required by arquillian-cube (e.g. namespace) and reuses the OpenShiftClient created by arquillian-cube.