### PR TITLE
Sometimes parallel handler waits for the RunInPod, but it is already ready.

### DIFF
--- a/utils/src/main/java/org/jboss/arquillian/ce/utils/AbstractCEContainer.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/utils/AbstractCEContainer.java
@@ -230,8 +230,10 @@ public abstract class AbstractCEContainer<T extends Configuration> implements De
         } finally {
             // reset parallel handler
             if (isSPI()) {
+                log.info("Cleaning parallel handler {SPI}");
                 parallelHandler.clearSPI();
             } else {
+                log.info("Cleaning parallel handler {MAIN}");
                 parallelHandler.clearMain();
             }
         }
@@ -260,14 +262,14 @@ public abstract class AbstractCEContainer<T extends Configuration> implements De
 
         if (isSPI()) {
             // resume SPI since it is ready -- Main can move on
+            log.info("Resuming OnSPI");
             parallelHandler.resumeOnSPI();
         }
 
         if (runInPodContainer != null && !isSPI()) {
             // reset
+            log.info("runInPodContainer is not null and SPI " + isSPI());
             parallelHandler.initSPI();
-            // wait for runinpod to finish
-            parallelHandler.waitOnSPI();
 
             // check if we got some error in SPI / parallel handling
             Throwable error = parallelHandler.getErrorFromSPI();


### PR DESCRIPTION
Sometines the parallaleHandler waits for the RunInPod get ready, but it is.
Looking in the thread dump retrieved from arq tests process we have this:


`"main" #1 prio=5 os_prio=0 tid=0x00007fc178009000 nid=0x5c2a in Object.wait() [0x00007fc1807b1000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at java.lang.Object.wait(Object.java:502)
        at org.jboss.arquillian.ce.utils.ParallelHandle.doWait(ParallelHandle.java:90)
        - locked <0x00000007092f3030> (a org.jboss.arquillian.ce.utils.ParallelHandle)
        at org.jboss.arquillian.ce.utils.ParallelHandler.waitOnSPI(ParallelHandler.java:72)
        at org.jboss.arquillian.ce.utils.AbstractCEContainer.deployInternal(AbstractCEContainer.java:270)
        at org.jboss.arquillian.ce.utils.AbstractCEContainer.deploy(AbstractCEContainer.java:229)
        at org.jboss.arquillian.container.impl.client.container.ContainerDeployController$3.call(ContainerDeployController.java:161)
        at org.jboss.arquillian.container.impl.client.container.ContainerDeployController$3.call(ContainerDeployController.java:128)
        at org.jboss.arquillian.container.impl.client.container.ContainerDeployController.executeOperation(ContainerDeployController.java:271)
        at org.jboss.arquillian.container.impl.client.container.ContainerDeployController.deploy(ContainerDeployController.java:127)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
`

After this: https://github.com/jboss-openshift/ce-arq/blob/master/utils/src/main/java/org/jboss/arquillian/ce/utils/AbstractCEContainer.java#L270

The resumeOnSPI is not called then the lock above will happen.

Please validate this proposed solution.
