### PR TITLE
Ignore template creation

### DIFF
--- a/utils/src/main/java/org/jboss/arquillian/ce/utils/TemplateUtils.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/utils/TemplateUtils.java
@@ -61,12 +61,9 @@ public class TemplateUtils {
 
     public static String readTemplateUrl(Template template, TemplateAwareConfiguration configuration, StringResolver resolver) {
         String templateUrl = template == null ? null : template.url();
-        if (templateUrl == null || templateUrl.length() == 0) {
-            templateUrl = resolver.resolve(configuration.getTemplateURL());
-        }
 
-        if (templateUrl == null) {
-            throw new IllegalArgumentException("Missing template URL! Either add @Template to your test or add -Dopenshift.template.url=<url>");
+        if (null != configuration.getTemplateURL()) {
+            templateUrl = configuration.getTemplateURL();
         }
 
         return templateUrl;


### PR DESCRIPTION
with template creation:
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.jboss.as.test.integration.auditlog.TLSAuditLogToTCPSyslogTestCase
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 154.367 sec - in org.jboss.as.test.integration.auditlog.TLSAuditLogToTCPSyslogTestCase
Running org.jboss.as.test.integration.beanvalidation.BeanValidationTestCase
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.325 sec - in org.jboss.as.test.integration.beanvalidation.BeanValidationTestCase
Running org.jboss.as.test.integration.beanvalidation.hibernate.scriptassert.ScriptAssertTestCase
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 sec - in org.jboss.as.test.integration.beanvalidation.hibernate.scriptassert.ScriptAssertTestCase
Running org.jboss.as.test.integration.beanvalidation.hibernate.validator.BootStrapValidationTestCase
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.842 sec - in org.jboss.as.test.integration.beanvalidation.hibernate.validator.BootStrapValidationTestCase






without:
from logs: INFO: Skipping the environment creation for org.jboss.as.test.integration.auditlog.TLSAuditLogToTCPSyslogTestCase

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.jboss.as.test.integration.auditlog.TLSAuditLogToTCPSyslogTestCase
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 109.862 sec - in org.jboss.as.test.integration.auditlog.TLSAuditLogToTCPSyslogTestCase
Running org.jboss.as.test.integration.beanvalidation.BeanValidationTestCase
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.46 sec - in org.jboss.as.test.integration.beanvalidation.BeanValidationTestCase
Running org.jboss.as.test.integration.beanvalidation.hibernate.scriptassert.ScriptAssertTestCase
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 sec - in org.jboss.as.test.integration.beanvalidation.hibernate.scriptassert.ScriptAssertTestCase
Running org.jboss.as.test.integration.beanvalidation.hibernate.validator.BootStrapValidationTestCase
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.631 sec - in org.jboss.as.test.integration.beanvalidation.hibernate.validator.BootStrapValidationTestCase
