### PR TITLE
Add a "labels" parameter in OpenShiftHandle.execute(), making it more generic

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftHandle.java
+++ b/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftHandle.java
@@ -25,12 +25,13 @@ package org.jboss.arquillian.ce.api;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface OpenShiftHandle {
-    InputStream execute(int pod, int port, String path) throws Exception;
+    InputStream execute(Map<String, String> labels, int pod, int port, String path) throws Exception;
 
     void scaleDeployment(String name, int replicas) throws Exception;
 

--- a/utils/src/main/java/org/jboss/arquillian/ce/adapter/AbstractOpenShiftAdapter.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/adapter/AbstractOpenShiftAdapter.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.ce.resources.OpenShiftResourceHandle;
 import org.jboss.arquillian.ce.utils.Checker;
 import org.jboss.arquillian.ce.utils.Configuration;
 import org.jboss.arquillian.ce.utils.Containers;
-import org.jboss.arquillian.ce.utils.DeploymentContext;
 import org.jboss.arquillian.ce.utils.Operator;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
 import org.jboss.arquillian.core.api.Instance;
@@ -63,14 +62,9 @@ public abstract class AbstractOpenShiftAdapter implements OpenShiftAdapter {
 
     protected abstract Proxy createProxy();
 
-    public InputStream execute(int pod, int port, String path) throws Exception {
-        ProtocolMetaData pmd = pmdInstance.get();
-        if (pmd != null) {
-            Map<String, String> labels = DeploymentContext.getDeploymentContext(pmd).getLabels();
-            return getProxy().post(labels, pod, port, path);
-        } else {
-            throw new IllegalStateException("No ProtocolMetaData set!");
-        }
+    @Override
+    public InputStream execute(Map<String, String> labels, int pod, int port, String path) throws Exception {
+        return getProxy().post(labels, pod, port, path);
     }
 
     public synchronized Proxy getProxy() {


### PR DESCRIPTION
Currently execute() works only in the same deployment as the test. We have
now another use case that is the test running in a pod and the images we
are testing living in other pods.

So, by passing the labels to it we leave to callers the task of finding the
pods they want to "execute" stuff in.


======================
Note to reviewer:

Now the class field "pmdInstance" is no longer used. Can we drop it?