### PR TITLE
Give role bindings an unique name, upon creation

### DIFF
--- a/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
+++ b/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
@@ -362,7 +362,7 @@ public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
             .roleBindings()
             .inNamespace(configuration.getNamespace())
             .createNew()
-            .withNewMetadata().withName(roleRefName).endMetadata()
+            .withNewMetadata().withName(roleRefName + "-" + subjectName).endMetadata()
             .withNewRoleRef().withName(roleRefName).endRoleRef()
             .addToUserNames(userName)
             .addNewSubject().withKind("ServiceAccount").withNamespace(configuration.getNamespace()).withName(subjectName).endSubject()


### PR DESCRIPTION
Currently it's failing when creating more than one role (via
@RoleBindings annotation), due to the name being duplicated.

By appending the subjectName to the name of the bind we achieve
an unique name.