### PR TITLE
Add a labels parameter to adapter.getLog(), to better match a pod

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftHandle.java
+++ b/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftHandle.java
@@ -46,7 +46,17 @@ public interface OpenShiftHandle {
 
     void scaleDeployment(String name, int replicas) throws Exception;
 
-    String getLog(String name) throws Exception;
+    /**
+     * Get the logs for a given pod.
+     *
+     * Combines both arguments to find a matching pod.
+     *
+     * @param  prefix Pod's name prefix, may be null
+     * @param  labels The labels for selecting the pod, may be null
+     * @return The pod's log
+     * @throws Exception if a pod couldn't be found or if there's an error retrieving the log
+     */
+    String getLog(String prefix, Map<String, String> labels) throws Exception;
 
     List<String> getPods() throws Exception;
 

--- a/openshift/src/main/java/org/jboss/arquillian/ce/openshift/NativeOpenShiftAdapter.java
+++ b/openshift/src/main/java/org/jboss/arquillian/ce/openshift/NativeOpenShiftAdapter.java
@@ -348,7 +348,7 @@ public class NativeOpenShiftAdapter extends AbstractOpenShiftAdapter {
     }
 
     public void resumeDeployment(String name, int replicas) throws Exception {
-        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, name);
+        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, name, null);
         final IDeploymentConfig dc = client.get(ResourceKind.DEPLOYMENT_CONFIG, dcName, configuration.getNamespace());
         final Map<String, String> labels = dc.getReplicaSelector();
         try {
@@ -359,13 +359,13 @@ public class NativeOpenShiftAdapter extends AbstractOpenShiftAdapter {
     }
 
     protected Map<String, String> getLabels(String prefix) throws Exception {
-        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, prefix);
+        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, prefix, null);
         final IDeploymentConfig dc = client.get(ResourceKind.DEPLOYMENT_CONFIG, dcName, configuration.getNamespace());
         return dc.getReplicaSelector();
     }
 
     public void scaleDeployment(final String name, final int replicas) throws Exception {
-        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, name);
+        String dcName = getFirstResource(ResourceKind.DEPLOYMENT_CONFIG, name, null);
         final IDeploymentConfig dc = client.get(ResourceKind.DEPLOYMENT_CONFIG, dcName, configuration.getNamespace());
         final Map<String, String> labels = dc.getReplicaSelector();
         dc.setReplicas(replicas);
@@ -377,8 +377,8 @@ public class NativeOpenShiftAdapter extends AbstractOpenShiftAdapter {
         }
     }
 
-    private String getFirstResource(String kind, String prefix) throws Exception {
-        List<IResource> list = client.list(kind, configuration.getNamespace());
+    private String getFirstResource(String kind, String prefix, Map<String, String> labels) throws Exception {
+        List<IResource> list = client.list(kind, configuration.getNamespace(), labels);
         for (IResource r : list) {
             String name = r.getName();
             if (name.startsWith(prefix)) {
@@ -388,8 +388,8 @@ public class NativeOpenShiftAdapter extends AbstractOpenShiftAdapter {
         throw new Exception(String.format("No resource [%s] found starting with %s", kind, prefix));
     }
 
-    public String getLog(String name) throws Exception {
-        String podName = getFirstResource(ResourceKind.POD, name);
+    public String getLog(String prefix, Map<String, String> labels) throws Exception {
+        String podName = getFirstResource(ResourceKind.POD, prefix, labels);
         final IPod pod = client.get(ResourceKind.POD, podName, configuration.getNamespace());
         OpenShiftBinaryPodLogRetrieval l = new OpenShiftBinaryPodLogRetrieval(pod, client);
         try (Reader reader = new InputStreamReader(l.getLogs(false), "UTF-8")) {


### PR DESCRIPTION
The prefix argument, by itself is poor to find a pod, because you can
have many pods starting with the same prefix. For instance, in a
deployment with EAP+AMQ you can have 3 pods named:
 - eap-app-1-c7j8j
 - eap-app-amq-1-xx8xz
 - eap-app-1-build

All of them starting with "eap-app".

A "labels" argument then is added to better handle this situation. If
passed it will be used along with the prefix to find the pod.