### PR TITLE
Change the function called when checking the token

### DIFF
--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEProjectManager.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEProjectManager.java
@@ -57,7 +57,7 @@ public class CEProjectManager {
         //token is valid?
         try {
             //just do a request somewhere that requires authentication
-            client.getClientExt().inAnyNamespace().oAuthAccessTokens().list();
+            client.getClientExt().inAnyNamespace().projects().list();
         } catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
             String actualToken = client.getClientExt().getConfiguration().getOauthToken();
             if (actualToken != null) {


### PR DESCRIPTION
Use one that doesn't require special permissions on the server: projects()
only require an ordinary authentication.