### PR TITLE
HttpClient: Add an execute() version with options

### DIFF
--- a/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClient.java
+++ b/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClient.java
@@ -30,5 +30,6 @@ import java.io.IOException;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface HttpClient extends Closeable {
-    HttpResponse execute(HttpRequest request) throws IOException;
+    HttpResponse execute(HttpRequest request) throws IOException, InterruptedException;
+    HttpResponse execute(HttpRequest request, HttpClientExecuteOptions options) throws IOException, InterruptedException;
 }

--- a/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClientExecuteOptions.java
+++ b/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClientExecuteOptions.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.arquillian.ce.httpclient;
+
+/**
+ * Options for use with HttpClient.Execute() method. Use the
+ * HttpClientExecuteOptions.Builder to create an instance.
+ *
+ * @author Jonh Wendell
+ *
+ */
+public class HttpClientExecuteOptions {
+    private final int tries;
+    private final int delay;
+    private final int desiredStatusCode;
+
+    private HttpClientExecuteOptions(Builder b) {
+        tries = b.tries;
+        delay = b.delay;
+        desiredStatusCode = b.desiredStatusCode;
+    };
+
+    public int getTries() {
+        return tries;
+    }
+
+    public int getDelay() {
+        return delay;
+    }
+
+    public int getDesiredStatusCode() {
+        return desiredStatusCode;
+    }
+
+    public static class Builder {
+        private int tries = 1;
+        private int delay = 5;
+        private int desiredStatusCode = -1;
+
+        /**
+         * How many tries should we do before giving up. Default value is 1.
+         *
+         * @param value
+         * @return
+         */
+        public Builder tries(int value) {
+            tries = value;
+            return this;
+        }
+
+        /**
+         * Delay, in seconds, between tries. Default value is 5.
+         *
+         * @param value
+         * @return
+         */
+        public Builder delay(int value) {
+            delay = value;
+            return this;
+        }
+
+        /**
+         * If set, the response status code must match this value. If it
+         * doesn't, another try is made (see {@link #tries(int)}). Default value
+         * is -1, meaning we should not compare response codes.
+         *
+         * @param value
+         * @return
+         */
+        public Builder desiredStatusCode(int value) {
+            desiredStatusCode = value;
+            return this;
+        }
+
+        public HttpClientExecuteOptions build() {
+            return new HttpClientExecuteOptions(this);
+        }
+    }
+}


### PR DESCRIPTION
With options we offer a bit more flexibility for consumers, like
the possibility of trying a given URL "N" times if it returns
something different than "200 OK" for instance.