### PR TITLE
Drop an unsed argument in deleteEnvironment()

### DIFF
--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -126,11 +126,11 @@ public class CEEnvironmentProcessor {
      * In the future, this might be handled by stopping application Cube
      * objects, e.g. StopCube(application), DestroyCube(application).
      */
-    public void deleteEnvironment(@Observes(precedence = -10) AfterClass event, OpenShiftAdapter client, CECubeConfiguration configuration, TemplateDetails details) throws Exception {
-    	deleteEnvironment(event.getTestClass(), client, configuration, details);
+    public void deleteEnvironment(@Observes(precedence = -10) AfterClass event, OpenShiftAdapter client, CECubeConfiguration configuration) throws Exception {
+        deleteEnvironment(event.getTestClass(), client, configuration);
     }
     
-    private void deleteEnvironment(final TestClass testClass, OpenShiftAdapter client, CECubeConfiguration configuration, TemplateDetails details) throws Exception {
+    private void deleteEnvironment(final TestClass testClass, OpenShiftAdapter client, CECubeConfiguration configuration) throws Exception {
         if (configuration.performCleanup()) {
             log.info(String.format("Deleting environment for %s", testClass.getName()));
             client.deleteTemplate(testClass.getName());
@@ -179,7 +179,7 @@ public class CEEnvironmentProcessor {
                     // class name is template key
                 	resources = client.processTemplateAndCreateResources(tc.getName(), templateURL, values, labels);
                 } catch (Exception e){
-                	deleteEnvironment(tc, client, configuration, null);
+                    deleteEnvironment(tc, client, configuration);
                 	throw e;
                 }
             } else {


### PR DESCRIPTION
That argument sometimes - for example if there's no template
to instantiate - can not be injected. As such, it would receive
a value of null.

Worse, it will block the method from being executed, because the
arquillian behavior for methods with arguments that cannot be
injected is simply not to invoke them.

If this method (deleteEnvironment) is not invoked, then the cleanup
will not be done, leaving some resources behind.

So, if there are other tests to be executed after this and if they
have resources that clash with the previous one, they will fail due
to an attempt to create a duplicated resource.

Closes #33.