### PR TITLE
HttpClient: Don't raise an exception when response code isn't the des…

### DIFF
--- a/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClientImpl.java
+++ b/httpclient/src/main/java/org/jboss/arquillian/ce/httpclient/HttpClientImpl.java
@@ -48,6 +48,7 @@ class HttpClientImpl implements HttpClient {
         IOException exception = null;
         HttpUriRequest r = HttpRequestImpl.class.cast(request).unwrap();
         CloseableHttpResponse rawResponse = null;
+        HttpResponse response = null;
 
         for (int i = 0; i < options.getTries(); i++) {
             try {
@@ -55,7 +56,7 @@ class HttpClientImpl implements HttpClient {
                     EntityUtils.consume(rawResponse.getEntity());
                 }
                 rawResponse = client.execute(r);
-                HttpResponse response = new HttpResponseImpl(rawResponse);
+                response = new HttpResponseImpl(rawResponse);
                 if (options.getDesiredStatusCode() == -1 || response.getResponseCode() == options.getDesiredStatusCode()) {
                     return response;
                 }
@@ -81,9 +82,9 @@ class HttpClientImpl implements HttpClient {
 
         if (exception != null) {
             throw exception;
-        } else {
-            throw new IOException(String.format("Failed to execute proper request. [URL:%s]", r.getURI()));
         }
+
+        return response;
     }
 
     public void close() throws IOException {


### PR DESCRIPTION
…ired

Actually make it configurable through the HttpClientExecuteOptions, with
its default value being false.

In fact, if the response code isn't the desired this should be handled
as a test failure, not an exception.

Closes #37.