### PR TITLE
Added support for multiple template instantiation

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ce/api/TemplateResources.java
+++ b/api/src/main/java/org/jboss/arquillian/ce/api/TemplateResources.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.arquillian.ce.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
+ * @author <a href="mailto:kliberti@redhat.com">Kyle Liberti</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface TemplateResources {
+
+    /**
+     * If true, the templates will be instantiated synchronously. If false, the
+     * templates will be instantiated asynchronously, where each template will
+     * deploy after the template before it completes deployment. In both cases,
+     * the testrunner will delay until all templates are deployed and ready.
+     *
+     * @return template instantiation type
+     **/
+    boolean syncInstantiation() default true;
+
+    Template[] templates() default {};
+}


### PR DESCRIPTION
With this update, users can specify a TemplateResources annotation in the same style as the OpenShiftResources annotation within Arquillian tests in order to instantiate multiple templates. Users can also choose to instantiate the templates synchronously or asynchronously using the syncInstantiation paramter. The default for syncInstantiation is true.

e.g.
TemplateResources( syncInstantiation = true,  templates= { 
		Template(url ),
                Template(url ) }
)

n.b. The original method of template instantiation is still supported
Template(url)