### PR TITLE
F8OpenShiftAdapter: Fix the build on newer kubernetes-model API

### DIFF
--- a/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
+++ b/fabric8/src/main/java/org/jboss/arquillian/ce/fabric8/F8OpenShiftAdapter.java
@@ -680,7 +680,11 @@ public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
         if (mountSecret != null) {
             Volume volume = new Volume();
             volume.setName(mountSecret.volumeName());
-            volume.setSecret(new SecretVolumeSource(mountSecret.secretName()));
+
+            SecretVolumeSource svc = new SecretVolumeSource();
+            svc.setSecretName(mountSecret.secretName());
+            volume.setSecret(svc);
+
             ps.setVolumes(Collections.singletonList(volume));
         }
     }


### PR DESCRIPTION
The constructor SecretVolumeSource(String) doesn't exist anymore.