### PR TITLE
We should scale DC, not RC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
         <version.dockerjava>2.1.3</version.dockerjava>
         <version.ok-http-client>3.4.1</version.ok-http-client>
         <version.openshift.client>4.0.3.Final</version.openshift.client>
-        <version.fabric8>2.2.157</version.fabric8>
-        <version.fabric8.client>1.4.1</version.fabric8.client>
+        <version.fabric8>2.2.184</version.fabric8>
+        <version.fabric8.client>1.4.27</version.fabric8.client>
         <version.jgit>4.1.0.201509280440-r</version.jgit>
         <version.jackson>2.6.3</version.jackson>
         <version.meta-inf>1.6</version.meta-inf>
@@ -171,12 +171,6 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-api</artifactId>
                 <version>${version.fabric8}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>kubernetes-client</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
It's documented here: https://docs.openshift.org/latest/dev_guide/deployments/how_deployments_work.html#what-is-a-deployment
In short: We shouldn't touch RC's that are managed by a DC.

In order to be able to scale DC, we need to bump the
kubernetes-[api|client] library versions. As a side effect
of this bump we needed to change the way RoleBindings are
created.