### PR TITLE
Don't check for Persistent Volumes beforehand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Cloud Enablement Arquillian Support
 
-# PersistentVolumes and PersistentVolumeClaims
-
-In order to test PVs and PVCs the OpenShift user running the tests must have the permissions to view PVs. To set the permissions for the user (e.g. joe):
-
-oadm policy add-cluster-role-to-user view joe --config=/etc/origin/master/admin.kubeconfig
-
 # EAP
 
 To run tests against EAP, one **must** set these system properties / env vars (use your numbers / paths!):


### PR DESCRIPTION
This requires special privileges on the cluster, which is not
a good thing to depend on.

Regular users are able to use PV's through PVC's, but are not
able to list all PV's, which is what this feature does.

Being able to use the PV's, thus allowing the user to run the
tests are enough for our case use.

We can assume - and document - that the user is responsible
for configuring the Persistent Volumes on the cluster before
running the tests. This is out of the scope for the testsuite (
at least for now).