### PR TITLE
Don't consider empty properties as valid

### DIFF
--- a/utils/src/main/java/org/jboss/arquillian/ce/utils/Strings.java
+++ b/utils/src/main/java/org/jboss/arquillian/ce/utils/Strings.java
@@ -40,7 +40,7 @@ public class Strings {
 
     private static String getSystemPropertyOrEnvVar(String systemPropertyName, String envVarName, String defaultValue) {
         String answer = System.getProperty(systemPropertyName);
-        if (answer != null) {
+        if (answer != null && !answer.equals("")) {
             return checkForNone(answer);
         }
 


### PR DESCRIPTION
If we find a property that is defined but is empty, skip
it and continue the search for an environment variable.

Example:

Suppose we have in pom.xml, within the section <systemPropertyVariables>:

	<kubernetes.master>${kubernetes.master}</kubernetes.master>

And the user has defined the env variable KUBERNETES_MASTER.

Properties must have priority, but, in this scenario, it would
have the value "", and we are ignoring the env variable.

With this change, we take empty properties as "not found", proceeding
with the search for an env variable, and, if still not found, using
a default [if provided] value.