### PR TITLE
Initialize 'templates' with an empty list instead of null

### DIFF
--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CEEnvironmentProcessor.java
@@ -70,7 +70,7 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 public class CEEnvironmentProcessor {
 
     private final Logger log = Logger.getLogger(CEEnvironmentProcessor.class.getName());
-    private List<Template> templates;
+    private List<Template> templates = Collections.emptyList();
 
     public interface TemplateDetails {
         List<List<? extends OpenShiftResource>> getResources();


### PR DESCRIPTION
So that it can be safely iterated anywhere in the code.

Particularly, this fixes a NPE when the deploy fails in the
method createEnvironment() and then deleteEnvironment() gets
called. It iterates over the templates field, which has the
null value, once the method initializes it was never called
because the deployment failed.