### PR TITLE
Override getToken() to return the client's token

### DIFF
--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeConfiguration.java
@@ -24,6 +24,7 @@ package org.jboss.arquillian.ce.cube;
 
 import java.util.Map;
 
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.jboss.arquillian.ce.utils.Strings;
 import org.jboss.arquillian.ce.utils.TemplateConfiguration;
 
@@ -38,6 +39,8 @@ import static org.jboss.arquillian.ce.utils.Strings.isNotNullOrEmpty;
  */
 public class CECubeConfiguration extends TemplateConfiguration {
     private static final long serialVersionUID = 1L;
+
+    private OpenShiftClient client;
 
     private String routerHost = Strings.getSystemPropertyOrEnvVar("openshift.router.host");
     private int routerHttpPort = Integer.valueOf(Strings.getSystemPropertyOrEnvVar("openshift.router.httpPort", "80"));
@@ -113,5 +116,20 @@ public class CECubeConfiguration extends TemplateConfiguration {
             return defaultValue;
         }
         return value;
+    }
+
+    public void setClient(OpenShiftClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String getToken() {
+        String token = super.getToken();
+
+        if ((token == null || token.isEmpty()) && (client != null)) {
+            token = client.getClientExt().getConfiguration().getOauthToken();
+        }
+
+        return token;
     }
 }

--- a/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeInitializer.java
+++ b/cube/src/main/java/org/jboss/arquillian/ce/cube/CECubeInitializer.java
@@ -61,6 +61,7 @@ public class CECubeInitializer {
     }
     
     public void createOpenShiftAdapter(@Observes OpenShiftClient client, CECubeConfiguration configuration) {
+        configuration.setClient(client);
         openShiftAdapterProducer.set(new F8OpenShiftAdapter(client.getClientExt(), configuration));
     }
 }


### PR DESCRIPTION
If we have not explicitly provide a token, we still can get
the one being used by the client, if it exists.

So, from a library's user perspective, getToken() only returns
an empty string if 1) the user hasn't provided one and 2) the
openshift client could not retrieve one from the user's config
file (usually ~/.kube/config).