### PR TITLE
[WIP] Add support for defining custom image stream definition

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftImageStreamResource.java
+++ b/api/src/main/java/org/jboss/arquillian/ce/api/OpenShiftImageStreamResource.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.arquillian.ce.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Marek Goldmann
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface OpenShiftImageStreamResource {
+    /**
+     * URL to the image stream definition.
+     */
+    String url();
+
+    /**
+     * The image name to replace the image in the stream. If not provided
+     * image from the original image stream will be used.
+     */
+    String image();
+
+    /**
+     * Mark if the provided image is located in an insecure registry.
+     */
+    String insecure() default "true";
+}


### PR DESCRIPTION
This commit makes it possible to use the @OpenShiftImageStreamResource annotation
for cases where deploying an image stream is necessary. Image streams
provided using this annotation are parsed and optionally adjusted.

Things that could be overriden are:

1. image: image name to use for the specified image stream,
2. insecure: insecure registry setting (by default `true`)